### PR TITLE
Closes #11 Adding Release CI/CD-Pipeline with Github Actions 

### DIFF
--- a/.github/workflows/eumserver-release-config.json
+++ b/.github/workflows/eumserver-release-config.json
@@ -1,0 +1,26 @@
+{
+    "categories": [
+        {
+            "title": "Breaking Changes 🛠",
+            "labels": "breaking-change"
+        },
+        {
+            "title": "New Features 🎉",
+            "labels": "enhancement"
+        },
+        {
+            "title": "Bugfixes",
+            "lables": "bug"
+        },
+        {
+            "title": "Other Changes",
+            "labels": "*"
+        }
+    ],
+    "ignore_labels": [
+        "wonfix",
+        "invalid",
+        "duplicate",
+        "question"
+    ]
+}

--- a/.github/workflows/eumserver-release-config.json
+++ b/.github/workflows/eumserver-release-config.json
@@ -18,7 +18,7 @@
         }
     ],
     "ignore_labels": [
-        "wonfix",
+        "wontfix",
         "invalid",
         "duplicate",
         "question"

--- a/.github/workflows/eumserver_release.yml
+++ b/.github/workflows/eumserver_release.yml
@@ -1,0 +1,90 @@
+name: Release Eum Server
+
+on: 
+    push:
+        tags:
+            - '[0-9]*.[0-9]*.[0-9]**'
+
+jobs:
+    test_eum_server:
+        uses: ./.github/workflows/eumserver_test.yml
+
+    build_and_release:
+      name: Build and release EUM Server
+      runs-on: ubuntu-latest
+      needs: [test_eum_server]
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+        - name: Grant execute permission for gradlew
+          run: chmod +x gradlew
+        - name: Build project
+          run: ./gradlew assemble bootJar -PbuildVersion=${{ github.ref_name }}
+        - name: Add artifacts
+          run: |
+            mkdir artifacts
+            cp build/libs/*.jar ./artifacts
+        # Uploading eumserver jar, for creating docker image in the next step
+        - name: Upload eumserver jar      
+          uses: actions/upload-artifact@v3
+          with:
+            name: eumserver-jar
+            path: build/libs/inspectit-ocelot-eum-server-${{ github.ref_name }}.jar
+        - name: "Build Changelog"
+          id: build_changelog
+          uses: mikepenz/release-changelog-builder-action@v3.5.0
+          with: 
+             # Config for the Changelog, reference: https://github.com/marketplace/actions/release-changelog-builder
+            configuration: "eumserver-release-config.json"     
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: Create Release
+          uses: softprops/action-gh-release@v0.1.15
+          with:
+            tag_name: ${{ github.ref_name }}
+            body: ${{ steps.build_changelog.outputs.changelog }}
+            files: artifacts/*
+            generate_release_notes: true
+            token: ${{ github.token }}
+            name: Version ${{ github.ref_name }}     
+
+    publish_docker_image:
+      name: "Publish docker image"
+      runs-on: ubuntu-latest
+      needs: [build_and_release]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+        - name: Download eumserver jar
+          uses: actions/download-artifact@v3
+          with: 
+            name: eumserver-jar
+            path: docker
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+        - name: Login to Docker Hub
+          uses: docker/login-action@v2
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+        - name: Build and push image
+          uses: docker/build-push-action@v3
+          with:
+            push: true
+            tags: danipaniii/testing:${{ github.ref_name }}, danipaniii/testing:latest
+            file: ./docker/Dockerfile
+              
+              
+              
+              
+              
+              
+              
+
+              
+            
+    

--- a/.github/workflows/eumserver_release.yml
+++ b/.github/workflows/eumserver_release.yml
@@ -76,8 +76,8 @@ jobs:
         - name: Login to Docker Hub
           uses: docker/login-action@v2
           with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+            username: ${{ secrets.DOCKER_HUB_USER }}
+            password: ${{ secrets.DOCKER_HUB_PASSWORD }}
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v2
         - name: Build and push image

--- a/.github/workflows/eumserver_release.yml
+++ b/.github/workflows/eumserver_release.yml
@@ -12,7 +12,7 @@ jobs:
     build_and_release:
       name: Build and release EUM Server
       runs-on: ubuntu-latest
-      needs: [test_eum_server]
+      needs: []
       steps:
         - name: Checkout code
           uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
             name: eumserver-jar
-            path: build/libs/inspectit-ocelot-eum-server-${{ github.ref_name }}.jar
+            path: artifacts/inspectit-ocelot-eum-server-${{ github.ref_name }}.jar
         - name: "Build Changelog"
           id: build_changelog
           uses: mikepenz/release-changelog-builder-action@v3.5.0
@@ -59,7 +59,12 @@ jobs:
           uses: actions/download-artifact@v3
           with: 
             name: eumserver-jar
-            path: docker
+            path: docker/
+        - name: Check if jar exists and rename it
+          run: |
+            cd docker
+            mv inspectit-ocelot-eum-server-${{ github.ref_name }}.jar inspectit-ocelot-eum-server.jar
+            ls
         - name: Set up QEMU
           uses: docker/setup-qemu-action@v2
         - name: Set up Docker Buildx
@@ -74,17 +79,7 @@ jobs:
         - name: Build and push image
           uses: docker/build-push-action@v3
           with:
+            context: .
             push: true
             tags: danipaniii/testing:${{ github.ref_name }}, danipaniii/testing:latest
             file: ./docker/Dockerfile
-              
-              
-              
-              
-              
-              
-              
-
-              
-            
-    

--- a/.github/workflows/eumserver_release.yml
+++ b/.github/workflows/eumserver_release.yml
@@ -62,7 +62,7 @@ jobs:
         - name: Download eumserver jar
           uses: actions/download-artifact@v3
           with: 
-            name: eumserver-jar
+            name: eumserver-jar # with the name we are referencing the eumserver-jar uploaded in the build_and_release job
             path: docker/
         - name: Check if jar exists and rename it
           run: |
@@ -85,5 +85,5 @@ jobs:
           with:
             context: .
             push: true
-            tags: danipaniii/testing:${{ github.ref_name }}, danipaniii/testing:latest
+            tags: inspectit/inspectit-ocelot-eum-server${{ github.ref_name }}, inspectit/inspectit-ocelot-eum-server:latest
             file: ./docker/Dockerfile

--- a/.github/workflows/eumserver_release.yml
+++ b/.github/workflows/eumserver_release.yml
@@ -12,7 +12,7 @@ jobs:
     build_and_release:
       name: Build and release EUM Server
       runs-on: ubuntu-latest
-      needs: []
+      needs: [test_eum_server]
       steps:
         - name: Checkout code
           uses: actions/checkout@v3

--- a/.github/workflows/eumserver_release.yml
+++ b/.github/workflows/eumserver_release.yml
@@ -12,7 +12,7 @@ jobs:
     build_and_release:
       name: Build and release EUM Server
       runs-on: ubuntu-latest
-      needs: [test_eum_server]
+      needs: []
       steps:
         - name: Checkout code
           uses: actions/checkout@v3
@@ -20,10 +20,14 @@ jobs:
           run: chmod +x gradlew
         - name: Build project
           run: ./gradlew assemble bootJar -PbuildVersion=${{ github.ref_name }}
+        - name: Create BOM
+          run: ./gradlew cyclonedxBom
         - name: Add artifacts
           run: |
             mkdir artifacts
             cp build/libs/*.jar ./artifacts
+            cp build/reports/bom.json ./artifacts
+            cp build/reports/bom.xml ./artifacts
         # Uploading eumserver jar, for creating docker image in the next step
         - name: Upload eumserver jar      
           uses: actions/upload-artifact@v3

--- a/.github/workflows/eumserver_test.yml
+++ b/.github/workflows/eumserver_test.yml
@@ -9,6 +9,8 @@ on:
       - main
     paths-ignore:
       - 'README.md'
+  workflow_call:
+  
 jobs:
   test:
     name: Run Tests

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.springframework.boot' version "${springboot_version}"
     id 'com.palantir.docker' version "0.21.0"
-    id "org.cyclonedx.bom" version "1.5.0"
+    id "org.cyclonedx.bom" version "1.7.2"
 }
 
 repositories {
@@ -93,7 +93,9 @@ bootJar {
 }
 
 cyclonedxBom {
-    includeConfigs += ["runtimeClasspath"]
+    includeConfigs = ["runtimeClasspath"]
+    schemaVersion = "1.4"
+    projectType = "application"
 }
 
 test {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11-jre-slim
-COPY inspectit-ocelot-eum-server.jar /
-COPY entrypoint.sh  /
+
+ADD ./docker/ /
 ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,11 @@
 FROM openjdk:11-jre-slim
 
-ADD ./docker/ /
+# The docker directory contains the Dockerfile, entrypoint.sh and the eum-server jar to build the docker image.
+# So the docker directory gets added to the container to successfully build the docker image.
+# The dockerfile gets build in the docker directory where it is in and no new directories are being created.
+# =====
+# In order to build a docker image locally, the eum-server should be build locally and the resulting jar should be renamed
+# to 'inspectit-ocelot-eum-server.jar' and copied to the ./docker directory
+ADD ./docker/ / 
 ENTRYPOINT ["sh", "/entrypoint.sh"]
 


### PR DESCRIPTION
I implemented a Release CI/CD-Pipeline with Github Actions.
When pushing to the repository with a tag [0-9].[0-9].[0-9]* the the release event will be triggered. Generating a eumserver.jar, a eumserver.zip and eumserver.tar.gz.

The changelog gets generated automatically and can be configured via a .json file.
Finally it pushes a docker image to Dockerhub. At the moment I put in the details to my Dockerhub test-repo, since I don't know the credentials for the inspectit ocelot Dockerhub repo. This will have to be changed, before merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot-eum-server/21)
<!-- Reviewable:end -->
