### PR TITLE
Update GitHub notifications

### DIFF
--- a/.github/workflows/eumserver_security_check.yml
+++ b/.github/workflows/eumserver_security_check.yml
@@ -37,13 +37,18 @@ jobs:
         with:
           name: dependency-check-report-eum-server
           path: ${{ github.workspace }}/reports
-      - name: Send Notification
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*EUM-Server Dependency-Check Report*: ${{ steps.depcheck.outcome }}\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Since GitHub cannot send emails directly, we use an external API
+      - name: Send Notification via Resend
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
+              "to": ["info.inspectit@novatec-gmbh.de"],
+              "subject": "EUM-Server Dependency-Check Report - ${{ steps.depcheck.outcome }}",
+              "html": "<p>The Dependency-Check for inspectit-ocelot-eum-server completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"
+            }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome
         if: ${{ steps.depcheck.outcome == 'failure' }}

--- a/.github/workflows/eumserver_security_check.yml
+++ b/.github/workflows/eumserver_security_check.yml
@@ -9,7 +9,7 @@ jobs:
   security-check:
     name: Security Check
     runs-on: ubuntu-latest
-    container: openjdk:17-jdk-slim
+    container: eclipse-temurin:17
     steps:
       - uses: actions/checkout@v3
       - name: Grant execute permission for gradlew

--- a/.github/workflows/eumserver_test.yml
+++ b/.github/workflows/eumserver_test.yml
@@ -33,7 +33,7 @@ jobs:
   dependency-scan:
     name: Dependency Scan
     runs-on: ubuntu-latest
-    container: openjdk:17-jdk-slim
+    container: eclipse-temurin:17
     steps:
       - uses: actions/checkout@v3
       - name: Grant execute permission for gradlew

--- a/.github/workflows/eumserver_test.yml
+++ b/.github/workflows/eumserver_test.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
   pull_request:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
+      - '**.md'
+      - '.github/**'
   workflow_call:
 
 env:

--- a/.github/workflows/eumserver_test.yml
+++ b/.github/workflows/eumserver_test.yml
@@ -33,7 +33,7 @@ jobs:
   dependency-scan:
     name: Dependency Scan
     runs-on: ubuntu-latest
-    container: eclipse-temurin:17
+    container: openjdk:17-jdk-slim
     steps:
       - uses: actions/checkout@v3
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
Replace Slack notifications with Email. Since GitHub cannot send emails directy, we use [Resend](https://resend.com/).